### PR TITLE
Ensure slot isn't updated by price monitoring

### DIFF
--- a/src/pubwatch/kupo.py
+++ b/src/pubwatch/kupo.py
@@ -117,7 +117,7 @@ async def get_policy_from_fsp(fsp_policy_id: str, validity_token_name: str):
     return binascii.hexlify(cbor).decode()
 
 
-async def get_slot() -> str:
+async def get_slot(price_monitor: bool = False) -> str:
     """Retrieve and store slot somewhere for future reference. Return
     previous slot as a reference point for UTxO retrieval functions."""
     try:
@@ -140,6 +140,10 @@ async def get_slot() -> str:
         pass
     if int(slot) <= int(previous_slot):
         raise PubWatchException("slot hasn't changed since last update")
+    if price_monitor:
+        # Don't write when we're looking through the lens of the
+        # price monitor.
+        return previous_slot
     with open(
         os.path.join(tempfile.gettempdir(), SLOTFILE), "w", encoding="utf-8"
     ) as slot_file:

--- a/src/pubwatch/price_monitor.py
+++ b/src/pubwatch/price_monitor.py
@@ -240,12 +240,13 @@ async def request_deviations_kupo(monitor_url: str, feeds: dict, local: bool):
     """
     logging.info("using kupo for price-monitoring")
     try:
-        _ = await kupo.get_slot()
+        _ = await kupo.get_slot(price_monitor=True)
     except kupo.KupoError as err:
         raise kupo.KupoError(f"{err}") from err
     except kupo.PubWatchException:
-        # Ignore this as it's primarily used by pubwatch.
-        pass
+        # Return this time as another process (pubwatch) has likely
+        # just checked Kupo and we don't need to double our effort.
+        return
     fs_policy_id = await kupo.get_policy_from_fsp(
         fsp_policy_id=kupo.FSP_POLICY,
         validity_token_name=kupo.VALIDITY_TOKEN,


### PR DESCRIPTION
Price monitoring is a long-running process and needs to query the chain more often. If the slot hasn't been updated we can exit early. If not, we can query the chain.

We may reconsider the use of slot number in the future. It's impact is only small and we can probably query Kupo as much as we want.